### PR TITLE
Support multiple Error pixels

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "repository": "zentrick/iab-vast-parser",
   "bugs": "https://github.com/zentrick/iab-vast-parser/issues",
   "dependencies": {
-    "iab-vast-model": "^0.3.0"
+    "iab-vast-model": "^0.4.0"
   },
   "optionalDependencies": {
     "xmldom": "^0.1.22"

--- a/src/inherit/ad.js
+++ b/src/inherit/ad.js
@@ -19,8 +19,10 @@ export default ($ad, $impl, ad) => {
       .filter(hasValue)
       .map(createImpression))
   }
-  if ($impl.error != null && hasValue($impl.error)) {
-    ad.error = $impl.error._value
+  if ($impl.error != null) {
+    ad.errors.push(...$impl.error
+      .filter(hasValue)
+      .map($err => $err._value))
   }
   if ($impl.creatives != null && Array.isArray($impl.creatives.creative)) {
     $impl.creatives.creative.map(createCreative).forEach((creative) => {

--- a/src/vast/schema.js
+++ b/src/vast/schema.js
@@ -11,14 +11,14 @@ const collections = {
   Icon: ['IconViewTracking'],
   IconClicks: ['IconClickTracking'],
   Icons: ['Icon'],
-  InLine: ['Impression'],
+  InLine: ['Impression', 'Error'],
   MediaFiles: ['MediaFile'],
   NonLinear: ['NonLinearClickTracking'],
   NonLinearAds: ['NonLinear'],
   TrackingEvents: ['Tracking'],
   VAST: ['Ad'],
   VideoClicks: ['ClickTracking', 'CustomClick'],
-  Wrapper: ['Impression']
+  Wrapper: ['Impression', 'Error']
 }
 
 const freeforms = {

--- a/test/integration/expected/kaltura/vast3_demo.json
+++ b/test/integration/expected/kaltura/vast3_demo.json
@@ -324,6 +324,8 @@
             ]
           },
           "description": "",
+          "errors": [
+          ],
           "extensions": [
             {
               "_type": "Extension",
@@ -395,6 +397,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "preroll-2",

--- a/test/integration/expected/tremor-video/vast2Nonlinear.json
+++ b/test/integration/expected/tremor-video/vast2Nonlinear.json
@@ -43,6 +43,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "overlay-1",
@@ -87,6 +89,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "overlay-2",
@@ -131,6 +135,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "overlay-3",
@@ -175,6 +181,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "overlay-4",
@@ -219,6 +227,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "overlay-5",
@@ -263,6 +273,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "overlay-6",
@@ -307,6 +319,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "overlay-7",
@@ -351,6 +365,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "overlay-8",
@@ -395,6 +411,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "overlay-9",
@@ -439,6 +457,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "overlay-10",

--- a/test/integration/expected/tremor-video/vast2RegularLinear.json
+++ b/test/integration/expected/tremor-video/vast2RegularLinear.json
@@ -75,6 +75,8 @@
             }
           ]
         },
+        "errors": [
+        ],
         "extensions": [
         ],
         "id": "preroll-1",

--- a/test/integration/expected/tremor-video/vast2VPAIDLinear.json
+++ b/test/integration/expected/tremor-video/vast2VPAIDLinear.json
@@ -68,6 +68,8 @@
             }
           ]
         },
+        "errors": [
+        ],
         "extensions": [
         ],
         "id": "preroll-1",

--- a/test/integration/expected/tremor-video/vast_inline_linear.json
+++ b/test/integration/expected/tremor-video/vast_inline_linear.json
@@ -150,7 +150,9 @@
           ]
         },
         "description": "VAST 2.0 Instream Test 1",
-        "error": "http://myErrorURL/error",
+        "errors": [
+          "http://myErrorURL/error"
+        ],
         "extensions": [
         ],
         "id": "601364",

--- a/test/integration/expected/tremor-video/vast_inline_nonlinear.json
+++ b/test/integration/expected/tremor-video/vast_inline_nonlinear.json
@@ -149,7 +149,9 @@
           ]
         },
         "description": "NonLinear Test Campaign 1",
-        "error": "http://myErrorURL/error",
+        "errors": [
+          "http://myErrorURL/error"
+        ],
         "extensions": [
         ],
         "id": "602678",

--- a/test/integration/expected/tremor-video/vast_wrapper_linear_1.json
+++ b/test/integration/expected/tremor-video/vast_wrapper_linear_1.json
@@ -141,7 +141,9 @@
             }
           ]
         },
-        "error": "http://myErrorURL/wrapper/error",
+        "errors": [
+          "http://myErrorURL/wrapper/error"
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/tremor-video/vast_wrapper_linear_2.json
+++ b/test/integration/expected/tremor-video/vast_wrapper_linear_2.json
@@ -93,6 +93,8 @@
             }
           ]
         },
+        "errors": [
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/tremor-video/vast_wrapper_nonlinear_1.json
+++ b/test/integration/expected/tremor-video/vast_wrapper_nonlinear_1.json
@@ -80,7 +80,9 @@
             }
           ]
         },
-        "error": "http://myErrorURL/wrapper/error",
+        "errors": [
+          "http://myErrorURL/wrapper/error"
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/tremor-video/vast_wrapper_nonlinear_2.json
+++ b/test/integration/expected/tremor-video/vast_wrapper_nonlinear_2.json
@@ -106,6 +106,8 @@
             }
           ]
         },
+        "errors": [
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/inline/test_vast_inline_123.json
+++ b/test/integration/expected/unruly/inline/test_vast_inline_123.json
@@ -45,6 +45,8 @@
           ]
         },
         "description": "Example Description",
+        "errors": [
+        ],
         "extensions": [
           {
             "_type": "Extension",

--- a/test/integration/expected/unruly/inline/test_vast_inline_with-linear-ad.json
+++ b/test/integration/expected/unruly/inline/test_vast_inline_with-linear-ad.json
@@ -90,6 +90,8 @@
           ]
         },
         "description": "Test description #hashtag",
+        "errors": [
+        ],
         "extensions": [
         ],
         "id": "1",

--- a/test/integration/expected/unruly/inline/test_vast_inline_with-linear-and-non-linear-ads.json
+++ b/test/integration/expected/unruly/inline/test_vast_inline_with-linear-and-non-linear-ads.json
@@ -89,6 +89,8 @@
           ]
         },
         "description": "Test description #hashtag",
+        "errors": [
+        ],
         "extensions": [
           {
             "_type": "Extension",

--- a/test/integration/expected/unruly/inline/test_vast_inline_with-long-video.json
+++ b/test/integration/expected/unruly/inline/test_vast_inline_with-long-video.json
@@ -75,6 +75,8 @@
           ]
         },
         "description": "Test description #hashtag",
+        "errors": [
+        ],
         "extensions": [
           {
             "_type": "Extension",

--- a/test/integration/expected/unruly/inline/test_vast_inline_with-multiple-extensions.json
+++ b/test/integration/expected/unruly/inline/test_vast_inline_with-multiple-extensions.json
@@ -75,6 +75,8 @@
           ]
         },
         "description": "Test description #hashtag",
+        "errors": [
+        ],
         "extensions": [
           {
             "_type": "Extension",

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_chained-with-linear-and-non-linear-ads.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_chained-with-linear-and-non-linear-ads.json
@@ -37,7 +37,9 @@
             }
           ]
         },
-        "error": "http://example.com/error/ERRORCODE",
+        "errors": [
+          "http://example.com/error/ERRORCODE"
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_chained-with-no-ads.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_chained-with-no-ads.json
@@ -37,7 +37,9 @@
             }
           ]
         },
-        "error": "http://example.com/error/ERRORCODE",
+        "errors": [
+          "http://example.com/error/ERRORCODE"
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_no-nonlinear.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_no-nonlinear.json
@@ -66,7 +66,9 @@
             }
           ]
         },
-        "error": "https://pixel",
+        "errors": [
+          "https://pixel"
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_with-blank-ad.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_with-blank-ad.json
@@ -16,6 +16,8 @@
           "_value": [
           ]
         },
+        "errors": [
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_with-click-track-with-no-ids.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_with-click-track-with-no-ids.json
@@ -72,7 +72,9 @@
             }
           ]
         },
-        "error": "http://example.com/error/ERRORCODE",
+        "errors": [
+          "http://example.com/error/ERRORCODE"
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_with-custom-element.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_with-custom-element.json
@@ -37,7 +37,9 @@
             }
           ]
         },
-        "error": "http://example.com/error/ERRORCODE",
+        "errors": [
+          "http://example.com/error/ERRORCODE"
+        ],
         "extensions": [
           {
             "_type": "Extension",

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_with-extensions-with-property.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_with-extensions-with-property.json
@@ -72,7 +72,9 @@
             }
           ]
         },
-        "error": "http://example.com/error/ERRORCODE",
+        "errors": [
+          "http://example.com/error/ERRORCODE"
+        ],
         "extensions": [
           {
             "_type": "Extension",

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_with-linear-ad-only.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_with-linear-ad-only.json
@@ -53,7 +53,9 @@
             }
           ]
         },
-        "error": "http://example.com/error/ERRORCODE",
+        "errors": [
+          "http://example.com/error/ERRORCODE"
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_with-linear-and-non-linear-ads.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_with-linear-and-non-linear-ads.json
@@ -117,7 +117,9 @@
             }
           ]
         },
-        "error": "http://example.com/error/ERRORCODE",
+        "errors": [
+          "http://example.com/error/ERRORCODE"
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_with-linear-no-impression.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_with-linear-no-impression.json
@@ -53,7 +53,9 @@
             }
           ]
         },
-        "error": "http://example.com/error/ERRORCODE",
+        "errors": [
+          "http://example.com/error/ERRORCODE"
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_with-no-clicks.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_with-no-clicks.json
@@ -64,7 +64,9 @@
             }
           ]
         },
-        "error": "http://example.com/error/ERRORCODE",
+        "errors": [
+          "http://example.com/error/ERRORCODE"
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_with-no-creatives.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_with-no-creatives.json
@@ -16,6 +16,8 @@
           "_value": [
           ]
         },
+        "errors": [
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_with-non-linear-ad-only.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_with-non-linear-ad-only.json
@@ -37,7 +37,9 @@
             }
           ]
         },
-        "error": "http://example.com/error/ERRORCODE",
+        "errors": [
+          "http://example.com/error/ERRORCODE"
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/unruly/wrapper/vast_wrapper_with-quartile-tracking.json
+++ b/test/integration/expected/unruly/wrapper/vast_wrapper_with-quartile-tracking.json
@@ -71,6 +71,8 @@
             }
           ]
         },
+        "errors": [
+        ],
         "extensions": [
         ],
         "fallbackOnNoAd": false,

--- a/test/integration/expected/videoplaza/karbon.json
+++ b/test/integration/expected/videoplaza/karbon.json
@@ -154,7 +154,9 @@
             }
           ]
         },
-        "error": "https://pulse-demo.videoplaza.tv/proxy/tracker/v2?aid=0&cd=52&cf=long_form&dcid=d25462f4-ea19-4eaf-99b9-85de3f29d059&e=0&pid=test&rnd=%5BCACHEBUSTING%5D&tid=f05be29c-0258-11e6-aa5e-002590e80b87&tt=p&ua=%5Bua%5D&uc=%5Buc%5D",
+        "errors": [
+          "https://pulse-demo.videoplaza.tv/proxy/tracker/v2?aid=0&cd=52&cf=long_form&dcid=d25462f4-ea19-4eaf-99b9-85de3f29d059&e=0&pid=test&rnd=%5BCACHEBUSTING%5D&tid=f05be29c-0258-11e6-aa5e-002590e80b87&tt=p&ua=%5Bua%5D&uc=%5Buc%5D"
+        ],
         "extensions": [
           {
             "_type": "Extension",

--- a/test/integration/expected/zentrick/pricing.json
+++ b/test/integration/expected/zentrick/pricing.json
@@ -68,6 +68,8 @@
             }
           ]
         },
+        "errors": [
+        ],
         "extensions": [
         ],
         "id": "preroll-1",

--- a/test/integration/expected/zentrick/sequence.json
+++ b/test/integration/expected/zentrick/sequence.json
@@ -70,6 +70,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "preroll-1",
@@ -144,6 +146,8 @@
               }
             ]
           },
+          "errors": [
+          ],
           "extensions": [
           ],
           "id": "preroll-2",

--- a/test/lib/marshal.js
+++ b/test/lib/marshal.js
@@ -18,7 +18,7 @@ const getPropertyNames = (proto) => {
 const marshalObject = (obj) => {
   const result = Object.create(null)
   const props = getPropertyNames(Object.getPrototypeOf(obj))
-    .filter((name) => (name !== '$type'))
+    .filter((name) => (name !== '$type' && name !== 'error'))
   for (const prop of props) {
     const value = obj[prop]
     if (value != null) {


### PR DESCRIPTION
@timdp allow for multiple Error pixels in VAST documents, since this is allowed by VAST 3.0 and later