### PR TITLE
Handle empty <Duration>

### DIFF
--- a/src/util/parse-time.js
+++ b/src/util/parse-time.js
@@ -1,9 +1,12 @@
 const re = /^\s*(\d+):(\d+):(\d+(?:\.\d+)?)\s*$/
 
 export default (str) => {
+  if (typeof str !== 'string') {
+    return null
+  }
   const m = re.exec(str)
   if (m == null) {
-    throw new Error(`Failed to parse time "${str}"`)
+    return null
   }
   return ((parseInt(m[1], 10) * 60) + parseInt(m[2], 10)) * 60 + parseFloat(m[3])
 }

--- a/test/fixtures/strict/zentrick/empty-duration.xml
+++ b/test/fixtures/strict/zentrick/empty-duration.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST version="2.0">
+  <Ad id="preroll-2">
+    <InLine>
+      <AdSystem>2.0</AdSystem>
+      <AdTitle>5773100</AdTitle>
+      <Creatives>
+        <Creative>
+          <Linear>
+            <Duration/>
+            <MediaFiles>
+              <MediaFile height="270" width="370" type="application/x-shockwave-flash"><![CDATA[http://static.scanscout.com/ads/vpaidad3.swf?adData=http%3A//app.scanscout.com/ssframework/adStreamJSController.xml%3Fa%3Dgetadscheduleforcontent%26PI%3D567%26scheduleVersion%3Dnull%26HI%3D567|preroll|7496075541100999745%26AI%3D0]]></MediaFile>
+            </MediaFiles>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
+</VAST>

--- a/test/integration/expected/strict/zentrick/empty-duration.json
+++ b/test/integration/expected/strict/zentrick/empty-duration.json
@@ -1,0 +1,58 @@
+{
+  "_type": "VAST",
+  "ads": {
+    "_type": "SortedList",
+    "_value": [
+      {
+        "_type": "InLine",
+        "adSystem": {
+          "_type": "AdSystem",
+          "name": "2.0"
+        },
+        "adTitle": "5773100",
+        "categories": [
+        ],
+        "creatives": {
+          "_type": "SortedList",
+          "_value": [
+            {
+              "_type": "Creative",
+              "extensions": [
+              ],
+              "linear": {
+                "_type": "Linear",
+                "icons": [
+                ],
+                "interactiveCreativeFiles": [
+                ],
+                "mediaFiles": [
+                  {
+                    "_type": "MediaFile",
+                    "height": 270,
+                    "type": "application/x-shockwave-flash",
+                    "uri": "http://static.scanscout.com/ads/vpaidad3.swf?adData=http%3A//app.scanscout.com/ssframework/adStreamJSController.xml%3Fa%3Dgetadscheduleforcontent%26PI%3D567%26scheduleVersion%3Dnull%26HI%3D567|preroll|7496075541100999745%26AI%3D0",
+                    "width": 370
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "errors": [
+        ],
+        "extensions": [
+        ],
+        "id": "preroll-2",
+        "impressions": [
+        ],
+        "surveys": [
+        ],
+        "verifications": [
+        ]
+      }
+    ]
+  },
+  "errors": [
+  ],
+  "version": "2.0"
+}


### PR DESCRIPTION
We currently throw if a `<Duration>` element does not contain a valid time string.

This PR relaxes that into returning `null`, but the work is unfinished.

Given that `<Duration>` is a required element, an invalid duration string makes the VAST invalid, so throwing is still the correct behavior. However, we have limited support for "loose mode". We should still throw in strict mode.