### PR TITLE
Add browser.js to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "files": [
     "src/",
     "lib/",
-    "index.js"
+    "index.js",
+    "browser.js"
   ],
   "scripts": {
     "build": "rimraf lib && babel src -d lib",


### PR DESCRIPTION
A `browser` field is included in `package.json`, but the file it points to - `browser.js` is not distributed on npm at the moment (`v1.0.2`).

Include the existing `browser.js` in `files` so it will be published.